### PR TITLE
Allow to read from named pipes

### DIFF
--- a/lib/Mixin/Linewise/Readers.pm
+++ b/lib/Mixin/Linewise/Readers.pm
@@ -95,7 +95,7 @@ sub _mk_read_file {
     # Check the file
     Carp::croak "no filename specified"           unless $filename;
     Carp::croak "file '$filename' does not exist" unless -e $filename;
-    Carp::croak "'$filename' is not a plain file" unless -f _;
+    Carp::croak "'$filename' is not a plain file" unless -r _;
 
     my $handle = IO::File->new($filename, "<:$binmode")
       or Carp::croak "couldn't read file '$filename': $!";


### PR DESCRIPTION
The -f switch ensures that only plain files are used to read from. But
there are other types of files that are readable, but not plain files. An example
is a named pipe. These should be treated as normal, and I guess the
intention of the tests are to check if we can read from a file.

With this change we allow reading from special files which are tested to
be readable.